### PR TITLE
S3 example was missing the method parameter

### DIFF
--- a/docs/s3.md
+++ b/docs/s3.md
@@ -46,6 +46,6 @@ Basically, if you use PUT, you can't wrap your file in a `FormData` instance. In
 ~~~js
 const getUploadParams = async ({ file, meta: { name } }) => {
   const { uploadUrl, fileUrl } = await myApiService.getPresignedUploadParams(name)
-  return { body: file, meta: { fileUrl }, url: uploadUrl }
+  return { method:"PUT", body: file, meta: { fileUrl }, url: uploadUrl }
 }
 ~~~


### PR DESCRIPTION
The  method:"PUT" parameter is required for getUploadParams to work

Otherwise you will get errors when you try to upload using the presigned url